### PR TITLE
Propagate asyncFn types to the returned function.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 export * from './atomic-option'
 
-export default function atomic(asyncFn: (...args: any[]) => Promise<any>, thisObj?: any) {
+type AsyncFunction<P extends any[], R extends Promise<any>> = (...args: P) => R
+
+export default function atomic<P extends any[],R extends Promise<any>>(
+  asyncFn: AsyncFunction<P,R>, 
+  thisObj?: any
+): typeof asyncFn {
   const queue: any[] = []
   return (...args) => {
     queue.push(


### PR DESCRIPTION
This will propagate the types in the passed async function to the function returned from atomic().

For example, if I pass the following:
```ts
const atomicFn = atomic(async (e: string) => {})
```

This PR will give `atomicFn` the signature:
```ts
(e: string) => Promise<void>
```

Instead of:
```ts
(...args:any[]) => Promise<any>
```